### PR TITLE
each said to return void but should have returned self. This collides…

### DIFF
--- a/src/Collection.php
+++ b/src/Collection.php
@@ -146,7 +146,7 @@ class Collection implements CollectionContract, ArrayAccess, Countable, Iterator
      *
      * @param callable $callable
      *
-     * @return void
+     * @return self
      */
     public function each(callable $callback)
     {


### PR DESCRIPTION
each() said to return void but should have returned self. This collides with phpstan used on rivescript-php.